### PR TITLE
更新了语音消息处理和引用

### DIFF
--- a/DingtalkStreamDemo/DefaultMessageHandler.cs
+++ b/DingtalkStreamDemo/DefaultMessageHandler.cs
@@ -1,12 +1,6 @@
 ﻿using Jusoft.DingtalkStream.Core;
 using Jusoft.DingtalkStream.Robot;
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace DingtalkStreamDemo
 {
     internal class DefaultMessageHandler : IDingtalkStreamMessageHandler
@@ -35,7 +29,7 @@ namespace DingtalkStreamDemo
                         // 通过消息类型 robotMessage.MsgType 来识别具体的消息内容
 
                         // 获取语音消息内容
-                        //var content=robotMessage.GetAudioContent();
+                        var content = robotMessage.GetAudioContent();
                         // 获取富文件消息内容
                         //var content=robotMessage.GetFileContent();
                         // 获取富图片消息内容

--- a/Jusoft.DingtalkStream.Core/Jusoft.DingtalkStream.Core.csproj
+++ b/Jusoft.DingtalkStream.Core/Jusoft.DingtalkStream.Core.csproj
@@ -16,9 +16,9 @@ C# 版本的钉钉Stream模式API SDK，支持订阅内容扩展，目前有【�
 		<PackageReleaseNotes>Dingtalk Stream SDK</PackageReleaseNotes>
 		<PackageIcon>logo.png</PackageIcon>
 		<FileVersion>0.1.4</FileVersion>
-		<AssemblyVersion>1.0.0</AssemblyVersion>
+		<AssemblyVersion>1.0.1</AssemblyVersion>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>1.0.0</Version>
+		<Version>1.0.1</Version>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/Jusoft.DingtalkStream.Robot/Extensions/ReceivedRobotMessageExtensions.cs
+++ b/Jusoft.DingtalkStream.Robot/Extensions/ReceivedRobotMessageExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Text.Json;
 
 namespace Jusoft.DingtalkStream.Robot
 {
@@ -34,10 +33,12 @@ namespace Jusoft.DingtalkStream.Robot
                 throw new ArgumentException("消息类型不是语音消息");
             }
             var content = robotMessage.Payload.GetProperty("content");
+
+            content.TryGetProperty("duration", out JsonElement duration);
             return new ReceivedRobotMessage.AudioContent
             {
                 DownloadCode = content.GetProperty("downloadCode").GetString(),
-                Duration = content.GetProperty("duration").GetInt64(),
+                Duration = duration.ValueKind == JsonValueKind.Undefined ? (long?)null : duration.GetInt64(),
                 Recognition = content.GetProperty("recognition").GetString(),
             };
         }
@@ -56,7 +57,7 @@ namespace Jusoft.DingtalkStream.Robot
             return new ReceivedRobotMessage.PictureContent
             {
                 DownloadCode = content.GetProperty("downloadCode").GetString(),
-                PictureDownloadCode = content.GetProperty("pictureDownloadCode")  .GetString(),
+                PictureDownloadCode = content.GetProperty("pictureDownloadCode").GetString(),
             };
 
         }

--- a/Jusoft.DingtalkStream.Robot/Jusoft.DingtalkStream.Robot.csproj
+++ b/Jusoft.DingtalkStream.Robot/Jusoft.DingtalkStream.Robot.csproj
@@ -18,7 +18,7 @@ CSharp SDK for Dingtalk Stream Mode API,Compared with the webhook mode, it is ea
 		<FileVersion>0.1.4</FileVersion>
 		<AssemblyVersion>1.0.0</AssemblyVersion>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>1.0.0</Version>
+		<Version>1.0.1</Version>
 	</PropertyGroup>
 
 

--- a/Jusoft.DingtalkStream.Robot/ReceivedRobotMessage.AudioContent.cs
+++ b/Jusoft.DingtalkStream.Robot/ReceivedRobotMessage.AudioContent.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Jusoft.DingtalkStream.Robot
+﻿namespace Jusoft.DingtalkStream.Robot
 {
     public partial class ReceivedRobotMessage
     {
@@ -14,7 +10,7 @@ namespace Jusoft.DingtalkStream.Robot
             /// <summary>
             /// 语音的时长，单位是（毫秒）。
             /// </summary>
-            public long Duration { get; internal set; }
+            public long? Duration { get; internal set; }
             /// <summary>
             /// 文件的下载码，用于换取下载文件的二进制文件
             /// <list type="bullet">

--- a/Jusoft.DingtalkStream.Robot/ReceivedRobotMessage.cs
+++ b/Jusoft.DingtalkStream.Robot/ReceivedRobotMessage.cs
@@ -18,73 +18,73 @@ namespace Jusoft.DingtalkStream.Robot
         /// <summary>
         /// 会话ID。
         /// </summary>
-        public string ConversationId => this.Payload.GetProperty("conversationId").GetString();
+        public string ConversationId => this.Payload.TryGetProperty("conversationId", out var conversationId) ? conversationId.GetString() : string.Empty;
         /// <summary>
         /// 加密的机器人所在的企业corpId。
         /// </summary>
-        public string ChatbotCorpId => this.Payload.GetProperty("chatbotCorpId").GetString();
+        public string ChatbotCorpId => this.Payload.TryGetProperty("chatbotCorpId", out var chatbotCorpId) ? chatbotCorpId.GetString() : string.Empty;
         /// <summary>
         /// 企业内部群中 @该机器人的成员userid。
         /// </summary>
-        public string ChatbotUserId => this.Payload.GetProperty("chatbotUserId").GetString();
+        public string ChatbotUserId => this.Payload.TryGetProperty("chatbotUserId", out var chatbotUserId) ? chatbotUserId.GetString() : string.Empty;
         /// <summary>
         /// 加密的消息ID。
         /// </summary>
-        public string MsgId => this.Payload.GetProperty("msgId").GetString();
+        public string MsgId => this.Payload.TryGetProperty("msgId", out var msgId) ? msgId.GetString() : string.Empty;
         /// <summary>
         /// 发送者昵称。
         /// </summary>
-        public string SenderNick => this.Payload.GetProperty("senderNick").GetString();
+        public string SenderNick => this.Payload.TryGetProperty("senderNick", out var senderNick) ? senderNick.GetString() : string.Empty;
         /// <summary>
         /// 是否为管理员。
         /// </summary>
-        public bool IsAdmin => this.Payload.GetProperty("isAdmin").GetBoolean();
+        public bool IsAdmin => this.Payload.TryGetProperty("isAdmin", out var isAdmin) ? isAdmin.GetBoolean() : false;
         /// <summary>
         /// 企业内部群中 @该机器人的成员userid。
         /// </summary>
-        public string SenderStaffId => this.Payload.GetProperty("senderStaffId").GetString();
+        public string SenderStaffId => this.Payload.TryGetProperty("senderStaffId", out var senderStaffId) ? senderStaffId.GetString() : string.Empty;
         /// <summary>
         /// 当前会话的Webhook地址过期时间。
         /// </summary>
-        public long SessionWebhookExpiredTime => this.Payload.GetProperty("sessionWebhookExpiredTime").GetInt64();
+        public long SessionWebhookExpiredTime => this.Payload.TryGetProperty("sessionWebhookExpiredTime", out var sessionWebhookExpiredTime) ? sessionWebhookExpiredTime.GetInt64() : 0;
         /// <summary>
         /// 消息的时间戳，单位（毫秒）。
         /// </summary>
-        public long CreateAt => this.Payload.GetProperty("createAt").GetInt64();
+        public long CreateAt => this.Payload.TryGetProperty("createAt", out var createAt) ? createAt.GetInt64() : 0;
         /// <summary>
         /// 企业内部群有的发送者当前群的企业corpId。
         /// </summary>
-        public string SenderCorpId => this.Payload.GetProperty("senderCorpId").GetString();
+        public string SenderCorpId => this.Payload.TryGetProperty("senderCorpId", out var senderCorpId) ? senderCorpId.GetString() : string.Empty;
         /// <summary>
         /// 1：单聊；2：群聊
         /// </summary>
-        public string ConversationType => this.Payload.GetProperty("conversationType").GetString();
+        public string ConversationType => this.Payload.TryGetProperty("conversationType", out var conversationType) ? conversationType.GetString() : string.Empty;
         /// <summary>
         /// 加密的发送者ID。<br />
         /// 使用senderStaffId，作为发送者userid值。
         /// </summary>
-        public string SenderId => this.Payload.GetProperty("senderId").GetString();
+        public string SenderId => this.Payload.TryGetProperty("senderId", out var senderId) ? senderId.GetString() : string.Empty;
         /// <summary>
         /// 群聊时才有的会话标题。
         /// </summary>
-        public string ConversationTitle => this.Payload.GetProperty("conversationTitle").GetString();
+        public string ConversationTitle => this.Payload.TryGetProperty("conversationTitle", out var conversationTitle) ? conversationTitle.GetString() : string.Empty;
         /// <summary>
         /// 是否在@列表中。
         /// </summary>
-        public bool IsInAtList => this.Payload.GetProperty("isInAtList").GetBoolean();
+        public bool IsInAtList => this.Payload.TryGetProperty("isInAtList", out var isInAtList) ? isInAtList.GetBoolean() : false;
         /// <summary>
         /// 当前会话的Webhook地址。
         /// </summary>
-        public string SessionWebhook => this.Payload.GetProperty("sessionWebhook").GetString();
-        public string RobotCode => this.Payload.GetProperty("robotCode").GetString();
+        public string SessionWebhook => this.Payload.TryGetProperty("sessionWebhook", out var sessionWebhook) ? sessionWebhook.GetString() : string.Empty;
+        public string RobotCode => this.Payload.TryGetProperty("robotCode", out var robotCode) ? robotCode.GetString() : string.Empty;
         /// <summary>
         /// 消息类型。
         /// </summary>
-        public string MsgType => this.Payload.GetProperty("msgtype").GetString();
+        public string MsgType => this.Payload.TryGetProperty("msgtype", out var msgType) ? msgType.GetString() : string.Empty;
         /// <summary>
         /// 被@人的信息。
         /// </summary>
-        public RobotMessageAtUserCollection AtUsers => new RobotMessageAtUserCollection(this.Payload.GetProperty("atUsers"));
+        public RobotMessageAtUserCollection AtUsers => this.Payload.TryGetProperty("atUsers", out var atUsers) ? new RobotMessageAtUserCollection(atUsers) : null;
 
     }
 }

--- a/Jusoft.DingtalkStream/Jusoft.DingtalkStream.csproj
+++ b/Jusoft.DingtalkStream/Jusoft.DingtalkStream.csproj
@@ -20,7 +20,7 @@
 		<AssemblyVersion>1.0.0</AssemblyVersion>
 		<PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
-		<Version>1.0.0</Version>
+		<Version>0.1.6</Version>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -43,8 +43,8 @@
 		<Version>$(FileVersion)</Version>
 	</PropertyGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\Jusoft.DingtalkStream.Core\Jusoft.DingtalkStream.Core.csproj" />
-		<ProjectReference Include="..\Jusoft.DingtalkStream.Robot\Jusoft.DingtalkStream.Robot.csproj" />
+		<ProjectReference Include="..\Jusoft.DingtalkStream.Core\Jusoft.DingtalkStream.Core.csproj"/>
+		<ProjectReference Include="..\Jusoft.DingtalkStream.Robot\Jusoft.DingtalkStream.Robot.csproj"/>
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
在`ReceivedRobotMessageExtensions.cs`文件中，移除了`System.Collections.Generic`和`System.Text`的引用，添加了`System.Text.Json`的引用。同时，对于语音消息的处理，我们增加了对"duration"属性是否存在的判断，如果不存在，则将`Duration`设置为null，否则获取其值。这是一个对于可选属性的处理改进。

在`ReceivedRobotMessage.AudioContent.cs`文件中，我们移除了`System`，`System.Collections.Generic`和`System.Text`的引用，并将`Duration`属性的类型从`long`改为了`long?`，这是为了处理"duration"属性可能不存在的情况。